### PR TITLE
Add optional payload for wakeups

### DIFF
--- a/doc/using.org
+++ b/doc/using.org
@@ -769,6 +769,13 @@ class ActorB(Actor):
   any single time, and the delivery of the ~WakeupMessage~ is
   interleaved into the normal incoming message stream for the Actor.
 
+  To distinguish ~WakeupMessage~ instances that have been scheduled
+  for different purposes, it is possible to supply a ~payload~
+  as a second parameter to ~.wakeupAfter()~. The ~payload~ can be
+  arbitrary but it is accrued against the actor's memory until it is
+  delivered. Hence, it is recommended to keep the ~payload~
+  reasonably small.
+
   There is no provision for cancelling a pending wakeup; the Actor
   should simply ignore the ~WakeupMessage~ when it is received.
 

--- a/thespian/actors.py
+++ b/thespian/actors.py
@@ -195,13 +195,16 @@ class Actor(object):
                 'not a valid ActorAddress for sending messages to')
         self._myRef.actor_send(targetAddr, msg)
 
-    def wakeupAfter(self, timePeriod):
+    def wakeupAfter(self, timePeriod, payload=None):
         """Requests delivery of a WakeupMessage after the specified period of
            time.  This may be called multiple times to request
-           multiple wakup deliveries.  There is no mechanism to cancel
+           multiple wakup deliveries.  The optional payload parameter can be
+           used to distinguish between different types of wakeups.  The payload
+           must be pickle-able.  As it is accrued  against the actor's memory,
+           it should be kept reasonably small.  There is no mechanism to cancel
            requested wakeups.
         """
-        self._myRef.wakeupAfter(timePeriod)
+        self._myRef.wakeupAfter(timePeriod, payload)
 
     def handleDeadLetters(self, startHandling=True):
         """Registers this Actor with the ActorSystem as a recipient of
@@ -473,17 +476,20 @@ class PoisonMessage(ActorSystemMessage):
 
 class WakeupMessage(ActorSystemMessage):
     """Message sent as a result of a .wakeupAfter() call.  The
-       delayPeriod value is the amount of time of the delay.
+       delayPeriod value is the amount of time of the delay. The payload
+       can be used to store timer-specific data.
     """
-    def __init__(self, delayPeriod):
+    def __init__(self, delayPeriod, payload=None):
         self.delayPeriod = delayPeriod
+        self.payload = payload
 
     def __str__(self):
-        return 'WakeupMessage(%s)' % str(self.delayPeriod)
+        return 'WakeupMessage(%s, %s)' % (str(self.delayPeriod),
+                                          str(self.payload))
 
     def __eq__(self, o):
         return isinstance(o, WakeupMessage) and \
-            self.delayPeriod == o.delayPeriod
+            self.delayPeriod == o.delayPeriod and self.payload == o.payload
 
     def __ne__(self, o): return not self.__eq__(o)
 

--- a/thespian/system/actorManager.py
+++ b/thespian/system/actorManager.py
@@ -440,8 +440,8 @@ class ActorManager(systemCommonBase):
     # ----------------------------------------------------------------------
     # Miscellaneous Functionality
 
-    def wakeupAfter(self, timePeriod):
-        self.transport.addWakeup(timePeriod)
+    def wakeupAfter(self, timePeriod, payload=None):
+        self.transport.addWakeup(timePeriod, payload)
 
     # ----------------------------------------------------------------------
     # Actors that involve themselves in topology

--- a/thespian/test/test_msg_Wakeup.py
+++ b/thespian/test/test_msg_Wakeup.py
@@ -8,6 +8,8 @@ class TestUnitExitRequestMsg(object):
         assert m1 == WakeupMessage(1)
         m2 = WakeupMessage('hi')
         assert m2 == WakeupMessage('hi')
+        m3 = WakeupMessage(1, 'some payload')
+        assert m3 == WakeupMessage(1, 'some payload')
 
     def test_inequality(self):
         m1 = WakeupMessage(1)
@@ -15,6 +17,7 @@ class TestUnitExitRequestMsg(object):
         assert m1 != WakeupMessage('hi')
         assert m1 != WakeupMessage(0)
         assert m1 != WakeupMessage(None)
+        assert m1 != WakeupMessage(1, 'some payload')
 
     def test_properties(self):
         assert 1 == WakeupMessage(1).delayPeriod

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@
 envlist = py26, py27, py33, py35
 
 [testenv]
+deps =
+    pytest
 commands = py.test -k 'Unit or Simple or Queue'
 setenv =
   PYTHONPATH = {toxinidir}


### PR DESCRIPTION
With this commit we add an optional `payload` parameter to `wakeupAfter()`. It
is intended to distinguish between calls to `wakeupAfter()` in the same actor but for
different purposes and is attached to the corresponding `WakeupMessage` when the
according timeout has expired.