### PR TITLE
globalName as Actor instance attribute

### DIFF
--- a/thespian/actors.py
+++ b/thespian/actors.py
@@ -699,6 +699,12 @@ class ActorSystem(object):
                                                 globalName,
                                                 sourceHash)
 
+    def getActor(self, globalName):
+        '''Called to get a "Primary" Actor (a top-level Actor owned by the
+           system itself) by globalName.
+        '''
+        return self._systemBase._globalNames.get(globalName)
+
     def tell(self, actorAddr, msg):
         """Sends msg to the Actor at the specified address.  No response is
            expected or awaited.

--- a/thespian/actors.py
+++ b/thespian/actors.py
@@ -699,12 +699,6 @@ class ActorSystem(object):
                                                 globalName,
                                                 sourceHash)
 
-    def getActor(self, globalName):
-        '''Called to get a "Primary" Actor (a top-level Actor owned by the
-           system itself) by globalName.
-        '''
-        return self._systemBase._globalNames.get(globalName)
-
     def tell(self, actorAddr, msg):
         """Sends msg to the Actor at the specified address.  No response is
            expected or awaited.

--- a/thespian/actors.py
+++ b/thespian/actors.py
@@ -120,7 +120,7 @@ class Actor(object):
        message handling functionality.
     '''
 
-    def __init__(self):
+    def __init__(self, globalName=None):
         """Called to initialize the Actor.
 
            Override this initialization method as needed in defined Actors.
@@ -141,7 +141,7 @@ class Actor(object):
            Actor).
 
         """
-        pass
+        self.globalName = globalName
 
     def __str__(self):
         return '{A:' + self.__class__.__name__ + \

--- a/thespian/system/actorManager.py
+++ b/thespian/system/actorManager.py
@@ -21,7 +21,7 @@ from functools import partial
 
 
 class ActorManager(systemCommonBase):
-    def __init__(self, childClass, transport, sourceHash, sourceToLoad,
+    def __init__(self, childClass, globalName, transport, sourceHash, sourceToLoad,
                  parentAddr, adminAddr,
                  childRequirements, currentSystemCapabilities,
                  concurrency_context):
@@ -36,6 +36,7 @@ class ActorManager(systemCommonBase):
         self._actorClass = childClass  # nb. this may be a string, and sourceHash is not loaded yet
         self._childReqs  = childRequirements
         self.actorInst   = None
+        self.globalName  = globalName
         atexit.register(self._shutdownActor)
         thesplog('Starting Actor %s at %s (parent %s, admin %s, srcHash %s)',
                  childClass, self.transport.myAddress,
@@ -54,7 +55,8 @@ class ActorManager(systemCommonBase):
                                       if self._sourceHash else None)
             # Now instantiate the identified Actor class object
             actorInst = withPossibleInitArgs(capabilities=self.capabilities,
-                                             requirements=self._childReqs) \
+                                             requirements=self._childReqs,
+                                             globalName=self.globalName) \
                                              .create(aClass)
             self._sCBStats.inc('Actor.Instance Created')
         except Exception as ex:
@@ -294,7 +296,7 @@ class ActorManager(systemCommonBase):
                 # this actor and the child can be created directly;
                 # otherwise the child actor creation will be forwarded
                 # to the Admin.
-                self._startChildActor(naa, newActorClass, self.myAddress,
+                self._startChildActor(naa, newActorClass, globalName, self.myAddress,
                                       notifyAddr = self.myAddress,
                                       childRequirements = targetActorRequirements,
                                       sourceHash = sourceHash,

--- a/thespian/system/admin/adminCore.py
+++ b/thespian/system/admin/adminCore.py
@@ -318,7 +318,7 @@ class AdminCore(systemCommonBase):
 
         try:
             self._startChildActor(
-                childAddr, envelope.message.actorClassName,
+                childAddr, envelope.message.actorClassName, envelope.message.globalName,
                 parentAddr=self.myAddress,  # Admin is surrogate parent
                 notifyAddr=self.myAddress,
                 childRequirements=envelope.message.targetActorReq,

--- a/thespian/system/multiprocCommon.py
+++ b/thespian/system/multiprocCommon.py
@@ -270,7 +270,7 @@ class MultiProcReplicator(object):
         self.mpcontext = concurrency_context
 
 
-    def _startChildActor(self, childAddr, childClass, parentAddr, notifyAddr,
+    def _startChildActor(self, childAddr, childClass, globalName, parentAddr, notifyAddr,
                          childRequirements=None,
                          sourceHash=None, sourceToLoad=None):
         """Create a new actor of type `childClass'.
@@ -336,6 +336,7 @@ class MultiProcReplicator(object):
                 if hasattr(childClass, '__name__') else childClass
         child = mp.Process(target=startChild,
                                         args=(ccArg,
+                                              globalName,
                                               endpointPrep,
                                               self.transport.__class__,
                                               sourceHash or self._sourceHash,
@@ -519,7 +520,7 @@ def shutdown_signal_detector(name, addr, am):
     return shutdown_signal_detected
 
 
-def startChild(childClass, endpoint, transportClass,
+def startChild(childClass, globalName, endpoint, transportClass,
                sourceHash, sourceToLoad,
                parentAddr, adminAddr, notifyAddr, loggerAddr,
                childRequirements, currentSystemCapabilities,
@@ -557,7 +558,7 @@ def startChild(childClass, endpoint, transportClass,
 
     logger = logging.getLogger('Thespian.ActorManager')
 
-    am = MultiProcManager(childClass, transport,
+    am = MultiProcManager(childClass, globalName, transport,
                           sourceHash, sourceToLoad,
                           parentAddr, adminAddr,
                           childRequirements, currentSystemCapabilities,

--- a/thespian/system/simpleSystemBase.py
+++ b/thespian/system/simpleSystemBase.py
@@ -492,6 +492,7 @@ class ActorSystemBase(WakeupManager):
                                    targetActorRequirements = targetActorRequirements,
                                    isTopLevel = True)
         if nar.instance:
+            nar.instance.globalName = globalName
             if globalName:
                 with self._private_lock:
                     self._globalNames[globalName] = naa

--- a/thespian/system/simpleSystemBase.py
+++ b/thespian/system/simpleSystemBase.py
@@ -494,6 +494,7 @@ class ActorSystemBase(WakeupManager):
         if nar.instance:
             nar.instance.globalName = globalName
             if globalName:
+                nar.instance.globalName = globalName
                 with self._private_lock:
                     self._globalNames[globalName] = naa
                 logger.info('Registered %s as global "%s" Primary Actor',

--- a/thespian/test/test_globalName.py
+++ b/thespian/test/test_globalName.py
@@ -7,6 +7,10 @@ class ThereCanBeOnlyOne(Actor):
     def receiveMessage(self, msg, sender):
         self.send(sender, "ONE: %s"%msg)
 
+class GlobalNameReporter(Actor):
+    def receiveMessage(self, msg, sender):
+        self.send(sender, self.globalName)
+
 class Parent(Actor):
     def receiveMessage(self, msg, sender):
         if msg == 'newChild':
@@ -131,3 +135,9 @@ class TestFuncGlobalName(object):
         assert "ONE: check" == asys.ask(uno, "check")
         assert "ONE: balance" == asys.ask(subDos, "balance")
 
+    def testGlobalNameInInstance(self, asys):
+        named = asys.createActor(GlobalNameReporter, globalName = "MyName")
+        assert "MyName" == asys.ask(named, "")
+
+        unnamed = asys.createActor(GlobalNameReporter)
+        assert asys.ask(unnamed, "") is None


### PR DESCRIPTION
`globalName` value passed to the `createActor()` call will be available in the actor instance as `self.globalName`

@kquick Old fork got all mixed up. New PR.