### PR TITLE
Make Thespian's internal logging threshold configurable

### DIFF
--- a/doc/using.org
+++ b/doc/using.org
@@ -1154,6 +1154,11 @@ before the ActorSystem is started:
        by developers writing Actors and is usually only needed by
        developers modifying Thespian internals.
 
+  * THESPLOG_THRESHOLD :: specifies the minimum log level that will get
+       written the THESPLOG_FILE. The default value is ~WARNING~ and the
+       following log levels are recognized: ~CRITICAL~, ~ERROR~, ~WARNING~,
+        ~INFO~, and ~DEBUG~.
+
 ** Actor Code Distribution
    :PROPERTIES:
    :CUSTOM_ID: hH-955ec990-a267-4d08-8f4d-5f980c777173

--- a/thespian/system/transport/TCPTransport.py
+++ b/thespian/system/transport/TCPTransport.py
@@ -1438,7 +1438,8 @@ class TCPTransport(asyncTransportBase, wakeupTransportBase):
             import traceback
             thesplog('OUCH!  Error deserializing received data:'
                      ' %s  (rdata="%s", extra="%s")',
-                     traceback.format_exc(), rdata, extra)
+                     traceback.format_exc(), rdata, extra,
+                     level=logging.ERROR)
             try:
                 inc.socket.send(ackDataErrMsg)
             except Exception:

--- a/thespian/system/utilis.py
+++ b/thespian/system/utilis.py
@@ -10,9 +10,18 @@ import inspect
 ### Logging
 ###
 
+# recognized logging level names for the Thespian internal log.
+_name_to_level = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG
+}
+
 # Default/current logging controls
 _thesplog_control_settings = (
-    logging.WARNING,
+    _name_to_level.get(os.getenv('THESPLOG_THRESHOLD'), logging.WARNING),
     False,
     os.getenv('THESPLOG_FILE_MAXSIZE', 50 * 1024) # 50KB by default
 )


### PR DESCRIPTION
With this commit, Thespian recognizes a new environment variable
`THESPLOG_THRESHOLD` to configure the minimum log level which is written
to Thespian's internal log file. The default value, `logging.WARNING`,
stays as is.

We also log deserialization error on `ERROR` level.

Closes #23