### PR TITLE
Fix a simultaneous file access error in Director when generating sources

### DIFF
--- a/thespian/director.py
+++ b/thespian/director.py
@@ -1493,8 +1493,8 @@ class SourceEncoding(object):
                 getattr(SourceEncoding,
                         '_ztt_' + (format or 'ThespianDirectorFMT1'))(
                             zfpath, sf, shasig)
-                os.rename(sftmp, sfpath)
-                return sfpath
+            os.rename(sftmp, sfpath)
+            return sfpath
         finally:
             try:
                 os.remove(sftmp)


### PR DESCRIPTION
When trying to create a source package using thespian.Director on Windows I got this error:

> PermissionError: [WinError 32] The process cannot access the file because it is being used by another process

It seems there is a blunder in the source code which tries to rename a file while keeping it open inside the context (by using the "with" statement).