### PR TITLE
Fix: "is" with a literal

### DIFF
--- a/thespian/runcommand.py
+++ b/thespian/runcommand.py
@@ -443,11 +443,11 @@ class RunCommand(ActorTypeDispatcher):
         updates_to = self.pending_commands[-1].output_updates
         if isinstance(updates_to, ActorAddress):
             self.send(updates_to, (CommandOutput
-                                   if outmark is 'normal' else
+                                   if outmark == 'normal' else
                                    CommandError)(command, new_output))
-        if outmark is 'normal':
+        if outmark == 'normal':
             self._log_normal_output(new_output)
-        elif outmark is 'error':
+        elif outmark == 'error':
             self._log_error_output(new_output)
 
     def _log_normal_output(self, new_output):


### PR DESCRIPTION
From Python 3.8 the interpreter will complain about using "is" with a
literal:
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior